### PR TITLE
feature: add component Button

### DIFF
--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -1,0 +1,43 @@
+.button {
+  display: inline-block;
+  padding: 16px;
+  background-color: #9d8de3;
+  color: #ffffff;
+  border-radius: 8px;
+  border: none;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+  transition:
+    background-color 0.3s,
+    transform 0.3s;
+  cursor: pointer;
+}
+
+.button.small {
+  font-size: 16px;
+  width: 120px;
+}
+
+.button.medium {
+  font-size: 24px;
+  width: 200px;
+}
+
+.button.large {
+  font-size: 32px;
+  width: 240px;
+}
+
+.button:hover {
+  background-color: #8c7bd4;
+  transform: translateY(-1px);
+}
+
+.button:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  outline: none;
+}
+
+.button:focus {
+  outline: none;
+}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,18 @@
+import "./Button.css";
+
+interface ButtonProps {
+  text: string;
+  size?: "small" | "medium" | "large";
+}
+
+const Button: React.FC<ButtonProps> = ({ text, size = "medium" }) => {
+  const buttonClass = `button ${size}`;
+
+  return (
+    <button className={buttonClass}>
+      <span>{text}</span>
+    </button>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
https://github.com/tamago-kake-gohan/tosho-kanri-ghost-client/issues/1

実装したもの
<img width="267" alt="image" src="https://github.com/tamago-kake-gohan/tosho-kanri-ghost-client/assets/121455567/bce19d9d-f1c2-4846-a8d3-60f0c2a0d42a">

textで表示する文字列を、size(small, medium, large)で大きさを指定できる。

sizeについては仮で実装したため、必要に応じて調整予定