### PR TITLE
fix: SelectGroup scroll

### DIFF
--- a/src/components/SelectGroup/SelectGroup.css
+++ b/src/components/SelectGroup/SelectGroup.css
@@ -10,6 +10,8 @@
   border-radius: 8px;
   padding-top: 16px;
   padding-bottom: 16px;
+  overflow-y: auto;
+  height: 300px;
 }
 
 .group-list {
@@ -48,4 +50,18 @@
 .group-list-item:hover {
   /* 選択されたアイテムのスタイル */
   background-color: rgba(255, 255, 255, 0.2);
+}
+
+/* スクロールバーのスタイル */
+.group-card::-webkit-scrollbar {
+  width: 8px;
+}
+
+.group-card::-webkit-scrollbar-track {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.group-card::-webkit-scrollbar-thumb {
+  background-color: rgba(157, 141, 227, 0.8);
+  border-radius: 4px;
 }

--- a/src/components/SelectGroup/SelectGroup.tsx
+++ b/src/components/SelectGroup/SelectGroup.tsx
@@ -21,6 +21,14 @@ const SelectGroup: React.FC = () => {
       id: 3,
       name: "Group 3",
     },
+    {
+      id: 4,
+      name: "Group 4",
+    },
+    {
+      id: 5,
+      name: "Group 5",
+    },
   ];
 
   const handleGroupClick = (groupId: number) => {


### PR DESCRIPTION
https://github.com/tamago-kake-gohan/tosho-kanri-ghost-client/issues/1

グループ数が多い場合はheightを制限し、スクロールバーを追加
<img width="454" alt="image" src="https://github.com/tamago-kake-gohan/tosho-kanri-ghost-client/assets/121455567/e3d4d684-5c25-4cb5-b3ac-a9ffc6f16145">
