### PR TITLE
fix: omit if it exceeds the column width

### DIFF
--- a/src/components/BookStatusTable/BookStatusTable.css
+++ b/src/components/BookStatusTable/BookStatusTable.css
@@ -34,6 +34,9 @@
   flex: 1;
   padding: 12px;
   color: white;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .table-item-bookname {


### PR DESCRIPTION
https://github.com/tamago-kake-gohan/tosho-kanri-ghost-client/issues/11

実装した画面
<img width="643" alt="image" src="https://github.com/tamago-kake-gohan/tosho-kanri-ghost-client/assets/121455567/a2bc2453-d13e-466e-9b13-e24e3a981b08">