### PR TITLE
fix: omit if it exceeds the column width

### DIFF
--- a/src/components/RequestTable/RequestTable.css
+++ b/src/components/RequestTable/RequestTable.css
@@ -34,6 +34,9 @@
   flex: 1;
   padding: 12px;
   color: white;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .table-item-bookname {


### PR DESCRIPTION
https://github.com/tamago-kake-gohan/tosho-kanri-ghost-client/issues/17

実装した画面
<img width="848" alt="image" src="https://github.com/tamago-kake-gohan/tosho-kanri-ghost-client/assets/121455567/36acbe16-e378-4705-9ba8-4cefb4943729">
