### PR TITLE
fix: rename component BookManagement -> LendManagement

### DIFF
--- a/src/app/lendManagement/page.tsx
+++ b/src/app/lendManagement/page.tsx
@@ -4,7 +4,7 @@ import "./lendManagement.css";
 import BookStatusTable from "@/components/BookStatusTable/BookStatusTable";
 import BookDetailModal from "@/components/BookDetailModal/BookDetailModal";
 
-const BookManagement = () => {
+const lendManagement = () => {
   const books = [
     {
       bookName: "書籍名A",
@@ -53,4 +53,4 @@ const BookManagement = () => {
   );
 };
 
-export default BookManagement;
+export default lendManagement;


### PR DESCRIPTION
bookManagementは登録書籍画面とするため、本ページはlendManagementにrenameする．
https://github.com/tamago-kake-gohan/tosho-kanri-ghost-client/issues/11